### PR TITLE
Config file improvements

### DIFF
--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57c70268",
+   "id": "9e3ac843",
    "metadata": {
     "deletable": false,
     "editable": false
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18a77b7b",
+   "id": "84d343c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +629,7 @@
    "outputs": [],
    "source": [
     "threshold = 0.5\n",
-    "isPercentile = True\n"
+    "isPercentile = True"
    ]
   },
   {

--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -217,7 +217,30 @@
     "    'synchronous_predictors': True, # whether or not we are using 'synchronous predictors'\n",
     "}\n",
     "\n",
-    "\n",
+    "# To load parameters from a previously-saved configuration file instead of setting them in the notebook,\n",
+    "# delete the rest of this cell and uncomment the following two lines, editing the filename as appropriate.\n",
+    "# config_file = '/home/aaron/Desktop/PyCPT/SAsiaJJAS_startMay/config'\n",
+    "# MOS, download_args, cpt_args, predictor_names, predictand_name, local_predictand_file = pycpt.load_configuration(config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57c70268",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
+   "source": [
+    "Set `force_download = False` to avoid re-downloading files you have already downloaded. Note: if you have changed anything in `download_args` since the data were last downloaded, you must set `force_download = True`, otherwise you will use the old data instead of the new."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18a77b7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "force_download = True"
    ]
   },
@@ -233,21 +256,6 @@
    "outputs": [],
    "source": [
     "domain_dir = pycpt.setup(case_dir, download_args[\"predictor_extent\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95274754",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Uncomment the following line & change the config filepath to save this configuration: \n",
-    "config_file = pycpt.save_configuration(case_dir / 'config', download_args, cpt_args, MOS, predictor_names, predictand_name, local_predictand_file)\n",
-    "print(\"Saved configuration to\", config_file)\n",
-    "\n",
-    "# Uncomment the following line & change the config filepath to load an existing configuration: \n",
-    "#MOS, download_args, cpt_args, predictor_names, predictand_name, local_predictand_file = pycpt.load_configuration('/home/aaron/Desktop/PyCPT/WAfricaJAS_startJun/config')"
    ]
   },
   {
@@ -507,7 +515,9 @@
    },
    "outputs": [],
    "source": [
-    "det_fcst, pr_fcst, pev_fcst, nextgen_skill = pycpt.construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir)"
+    "det_fcst, pr_fcst, pev_fcst, nextgen_skill = pycpt.construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir)\n",
+    "config_file = pycpt.save_configuration(case_dir / 'config', download_args, cpt_args, MOS, predictor_names, predictand_name, local_predictand_file)\n",
+    "print(\"Saved configuration to\", config_file)"
    ]
   },
   {

--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -219,8 +219,8 @@
     "\n",
     "# To load parameters from a previously-saved configuration file instead of setting them in the notebook,\n",
     "# delete the rest of this cell and uncomment the following two lines, editing the filename as appropriate.\n",
-    "# config_file = '/home/aaron/Desktop/PyCPT/SAsiaJJAS_startMay/config'\n",
-    "# MOS, download_args, cpt_args, predictor_names, predictand_name, local_predictand_file = pycpt.load_configuration(config_file)"
+    "# config_file_in = '/home/aaron/Desktop/PyCPT/SAsiaJJAS_startMay/config'\n",
+    "# MOS, download_args, cpt_args, predictor_names, predictand_name, local_predictand_file = pycpt.load_configuration(config_file_in)"
    ]
   },
   {
@@ -516,8 +516,8 @@
    "outputs": [],
    "source": [
     "det_fcst, pr_fcst, pev_fcst, nextgen_skill = pycpt.construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir)\n",
-    "config_file = pycpt.save_configuration(case_dir / 'config', download_args, cpt_args, MOS, predictor_names, predictand_name, local_predictand_file)\n",
-    "print(\"Saved configuration to\", config_file)"
+    "config_file_out = pycpt.save_configuration(case_dir / 'config', download_args, cpt_args, MOS, predictor_names, predictand_name, local_predictand_file)\n",
+    "print(\"Saved configuration to\", config_file_out)"
    ]
   },
   {


### PR DESCRIPTION
Save to the config file the list of predictors that were chosen to include in the ensemble, rather than the list of predictors that were initially considered for inclusion. This requires delaying config file creation, since `ensemble` doesn't get set until after the individual models have been evaluated.

Also now using different variables for the name of the input config file and the output config file, so we don't get them mixed up when running cells out of order.