### PR TITLE
Save reproducibility info in notebook instead of config file

### DIFF
--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -215,12 +215,7 @@
     "    'scree': True, # whether or not to save % explained variance for eof modes\n",
     "    'crossvalidation_window': 5,  # number of samples to leave out in each cross-validation step \n",
     "    'synchronous_predictors': True, # whether or not we are using 'synchronous predictors'\n",
-    "}\n",
-    "\n",
-    "# To load parameters from a previously-saved configuration file instead of setting them in the notebook,\n",
-    "# delete the rest of this cell and uncomment the following two lines, editing the filename as appropriate.\n",
-    "# config_file_in = '/home/aaron/Desktop/PyCPT/SAsiaJJAS_startMay/config'\n",
-    "# MOS, download_args, cpt_args, predictor_names, predictand_name, local_predictand_file = pycpt.load_configuration(config_file_in)"
+    "}"
    ]
   },
   {
@@ -515,9 +510,7 @@
    },
    "outputs": [],
    "source": [
-    "det_fcst, pr_fcst, pev_fcst, nextgen_skill = pycpt.construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir)\n",
-    "config_file_out = pycpt.save_configuration(case_dir / 'config', download_args, cpt_args, MOS, predictor_names, predictand_name, local_predictand_file)\n",
-    "print(\"Saved configuration to\", config_file_out)"
+    "det_fcst, pr_fcst, pev_fcst, nextgen_skill = pycpt.construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir)"
    ]
   },
   {
@@ -657,31 +650,7 @@
     "\n",
     "Choose a gridpoint within the predictand domain to plot the forecast and climatological probability of exceedance and PDF curves. If set to None, the centroid of the predictand domain will be used.\n",
     "\n",
-    "If you want to use a different color bar than the one used by default, assign the name of the desired color bar to the variable **color_bar**, None value will use the default color bars. If you are unaware of the available color bars, assign the value True to the variable **display_color_bars**. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3777f473",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "display_color_bars=False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3ea69659",
-   "metadata": {
-    "deletable": false,
-    "editable": false
-   },
-   "outputs": [],
-   "source": [
-    "if display_color_bars:\n",
-    "    get_colors_bars() "
+    "If you want to use a different color bar than the one used by default, assign the name of the desired color bar to the variable **color_bar**, None value will use the default color bars. If you are unaware of the available color bars, run `get_colors_bars()`."
    ]
   },
   {
@@ -709,6 +678,43 @@
    "outputs": [],
    "source": [
     "pycpt.plot_mme_flex_forecasts(predictand_name, exceedance_prob, point_latitude, point_longitude, download_args[\"predictand_extent\"], transformed_threshold, fcst_scale, climo_scale, fcst_mu, climo_mu, Y2, cpt_args['transform_predictand'], ntrain, Y, MOS, domain_dir,color_bar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9734a22",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
+   "source": [
+    "These final cells record information about the python environment that will be useful if we need to reproduce this configuration in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27d33647",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
+   "outputs": [],
+   "source": [
+    "!conda list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5df9367d",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
+   "outputs": [],
+   "source": [
+    "!conda list --explicit"
    ]
   }
  ],


### PR DESCRIPTION
Was anyone besides me attached to idea of the config file?

Kyle originally created the config file at my request. I was hoping that we could put a complete specification of the forecast configuration in a config file, and that file would be all we needed in order to set up their configuration in the FbF tool. But experience has shown that there are too many variations (e.g. local config files, custom Ingrid URLs), and it doesn't seem feasible for the config file to capture every possible variation. So instead, here I've added a notebook cell that runs `!conda list` to get the full list of package versions into the notebook, and I'll just ask people to send me their notebooks, with outputs included, instead of a config file.

Also in this same pull request I've simplified the colormap customization option, following how I did it in the subseasonal version.