### PR TITLE
Add RMSE to notebook

### DIFF
--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -360,6 +360,7 @@
     "    \"two_alternative_forced_choice\",\n",
     "    \"roc_area_below_normal\",\n",
     "    \"roc_area_above_normal\",\n",
+    "    \"root_mean_squared_error\",\n",
     "]"
    ]
   },
@@ -528,9 +529,10 @@
    },
    "outputs": [],
    "source": [
-    "skill_metrics = [\n",
+    "mme_skill_metrics = [\n",
     "    \"spearman\",\n",
-    "    \"2afc\",\n",
+    "    \"two_alternative_forced_choice\",\n",
+    "    \"root_mean_squared_error\",\n",
     "    \"generalized_roc\",\n",
     "    \"rank_probability_skill_score\",\n",
     "]"
@@ -547,7 +549,7 @@
    },
    "outputs": [],
    "source": [
-    "pycpt.plot_mme_skill(predictor_names, nextgen_skill, MOS, domain_dir, skill_metrics)"
+    "pycpt.plot_mme_skill(predictor_names, nextgen_skill, MOS, domain_dir, mme_skill_metrics)"
    ]
   },
   {

--- a/Operations/pycpt-operational.ipynb
+++ b/Operations/pycpt-operational.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "import pycpt\n",
     "import packaging\n",
-    "min_version = '2.9'\n",
+    "min_version = '2.9.2'\n",
     "assert packaging.version.parse(pycpt.__version__) >= packaging.version.parse(min_version), f'This notebook requires version {min_version} or higher of the pycpt library, but you have version {pycpt.__version__}. Please close the notebook, update your environment, and load the notebook again. See https://iri-pycpt.github.io/installation/'\n",
     "\n",
     "import cptdl as dl \n",


### PR DESCRIPTION
In PyCPT 2.9 we added RMSE to the list of available skill metrics, but (a) only for individual models, not for the MME, and (b) we didn't add the new metric to the demonstration notebook. PyCPT 2.9.2 (not yet released but it will be soon) fixes (a), and this PR fixes (b).

The skill cells now render like this:
![Screenshot from 2024-12-04 11-12-29](https://github.com/user-attachments/assets/5257fbe1-736a-476e-a1af-701fd46127e8)
![Screenshot from 2024-12-04 11-12-56](https://github.com/user-attachments/assets/86589245-fbbe-4e1d-9ec2-3bc1f7d04c27)
@awrobertson please confirm that this is what you want.